### PR TITLE
Adds a way to filter logs by module name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,15 +250,7 @@ impl log::Log for Log2 {
         // module
         let mut module = "".into();
         if self.module {
-            if file.starts_with("src/") {
-                if file.ends_with("/mod.rs") {
-                    module = format!("{}: ", &file[4..file.len() - 7]);
-                } else if file.ends_with(".rs") {
-                    module = format!("{}: ", &file[4..file.len() - 3]);
-                }
-            } else {
-                module = format!("{file}: ");
-            }
+            module = format!("[{}]", record.module_path().unwrap_or(&file));
         }
 
         // stdout
@@ -267,7 +259,7 @@ impl log::Log for Log2 {
             let open = "[".truecolor(0x87, 0x87, 0x87);
             let close = "]".truecolor(0x87, 0x87, 0x87);
             let line = format!(
-                "{open}{}{close} {open}{}{close} {module}{}",
+                "{open}{}{close} {open}{}{close} {module} {}",
                 Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),
                 level,
                 record.args()

--- a/tests/log2_module_filter.rs
+++ b/tests/log2_module_filter.rs
@@ -1,0 +1,37 @@
+use log2::*;
+
+#[test]
+fn module_filter() {
+    let _log2 = Log2::new()
+        .tee(true)
+        // only log messages from modules that contain "first"
+        .module_filter(|module| module.contains("first"))
+        .start();
+
+    first_module::foo();
+    second_module::bar();
+
+    mod first_module {
+        use log2::*;
+
+        pub fn foo() {
+            trace!("send order request to server");
+            debug!("receive order response");
+            info!("order was executed");
+            warn!("network speed is slow");
+            error!("network connection was broken");
+        }
+    }
+
+    mod second_module {
+        use log2::*;
+
+        pub fn bar() {
+            trace!("send order request to server");
+            debug!("receive order response");
+            info!("order was executed");
+            warn!("network speed is slow");
+            error!("network connection was broken");
+        }
+    }
+}


### PR DESCRIPTION
I added a simple way to filter logs by module name.
I also changed the module option to use `Record.module` which is already neatly formatted.