### PR TITLE
add support for explicitly disabling colors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub struct Log2 {
     levels: [ColoredString; 6],
     path: String,
     tee: bool,
+    color: bool,
     module: bool,
     filesize: u64,
     count: usize,
@@ -181,6 +182,7 @@ impl Log2 {
             levels,
             path: String::new(),
             tee: false,
+            color: true,
             module: true,
             filesize: 100 * 1024 * 1024,
             count: 10,
@@ -197,6 +199,12 @@ impl Log2 {
     // split the output to stdout
     pub fn tee(mut self, stdout: bool) -> Log2 {
         self.tee = stdout;
+        self
+    }
+
+    // use colors in the output to stdout
+    pub fn color(mut self, color: bool) -> Log2 {
+        self.color = color;
         self
     }
 
@@ -268,8 +276,12 @@ impl log::Log for Log2 {
         // stdout
         if self.tee {
             let level = &self.levels[record.level() as usize];
-            let open = "[".truecolor(0x87, 0x87, 0x87);
-            let close = "]".truecolor(0x87, 0x87, 0x87);
+            let (open, close) = if self.color {
+		("[".truecolor(0x87, 0x87, 0x87),
+		 "]".truecolor(0x87, 0x87, 0x87))
+	    } else {
+		("".into(), "".into())
+	    };
             let line = format!(
                 "{open}{}{close} {open}{}{close} {origin}{}",
                 Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),


### PR DESCRIPTION
While it's possible to use NO_COLOR this doesn't work properly if you use several libraries that can output colored text, and you want one of them to not output colored text, while keeping the colored text from the other one. Or you simply don't want to rely on environment variables at all.